### PR TITLE
Made client/server abstract

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -25,6 +25,7 @@ $config = new Config()
 new PhpCsFixerCodingStandard()->applyTo($config, [
     'native_constant_invocation' => false,
     'final_public_method_for_abstract_class' => false,
+    'fully_qualified_strict_types' => false,
 ]);
 
 return $config;

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ composer-normalize-check: ## Check that composer.json is normalized
 fix: fixer rector composer-normalize ## Run all fixing recipes
 .PHONY: fix
 
-check: fixer-check rector-check composer-validate composer-normalize-check deps-analyze phpstan test  ## Run all project checks
+check: fixer-check rector-check composer-validate composer-normalize-check deps-analyze phpstan compile-test-stub test  ## Run all project checks
 .PHONY: check
 
 compile-test-stub:

--- a/src/Client.php
+++ b/src/Client.php
@@ -5,49 +5,14 @@ declare(strict_types=1);
 namespace Thesis\Grpc;
 
 use Amp\Cancellation;
-use Amp\Http\Client\DelegateHttpClient;
 use Amp\NullCancellation;
-use Thesis\Grpc\Client\Internal\Http2;
 use Thesis\Grpc\Exception\ClientStreamIsClosed;
-use Thesis\Protobuf\Decoder;
 
 /**
  * @api
  */
-final readonly class Client
+interface Client
 {
-    private Http2\InterceptorComposer $interceptor;
-
-    private Http2\StreamFactory $streams;
-
-    /**
-     * @param non-empty-string $host
-     * @param list<Client\Interceptor> $interceptors
-     */
-    public function __construct(
-        string $host,
-        DelegateHttpClient $client,
-        Encoding\Encoder $encoder,
-        Compression\Compressor $compressor,
-        Decoder $protobuf,
-        array $interceptors = [],
-    ) {
-        $this->interceptor = new Http2\InterceptorComposer([
-            ...$interceptors,
-            new Http2\AppendControlMetadataInterceptor(
-                $encoder->name(),
-                $compressor->name(),
-            ),
-        ]);
-        $this->streams = new Http2\StreamFactory(
-            http: $client,
-            uri: new Http2\UriFactory($host),
-            errors: new Http2\ErrorHandler($protobuf),
-            encoder: $encoder,
-            compressor: $compressor,
-        );
-    }
-
     /**
      * @template In of object
      * @template Out of object
@@ -62,18 +27,7 @@ final readonly class Client
         Client\Invoke $invoke,
         Metadata $md = new Metadata(),
         Cancellation $cancellation = new NullCancellation(),
-    ): object {
-        $stream = $this->createStream(
-            $invoke,
-            $md,
-            $cancellation,
-        );
-
-        $stream->send($request);
-        $stream->close();
-
-        return $stream->receive();
-    }
+    ): object;
 
     /**
      * @template In of object
@@ -85,13 +39,5 @@ final readonly class Client
         Client\Invoke $invoke,
         Metadata $md = new Metadata(),
         Cancellation $cancellation = new NullCancellation(),
-    ): ClientStream {
-        /** @var ClientStream<In, Out> */
-        return $this->interceptor->intercept(
-            $invoke,
-            $md,
-            $cancellation,
-            $this->streams->create(...),
-        );
-    }
+    ): ClientStream;
 }

--- a/src/Client/Builder.php
+++ b/src/Client/Builder.php
@@ -151,7 +151,7 @@ final class Builder
 
     public function build(): Client
     {
-        return new Client(
+        return new Internal\AmphpHttpClient(
             host: $this->host ?? self::DEFAULT_HOST,
             client: $this->httpclient ?? new HttpClientBuilder()
                 ->usingPool(ConnectionLimitingPool::byAuthority(

--- a/src/Client/Internal/AmphpHttpClient.php
+++ b/src/Client/Internal/AmphpHttpClient.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Thesis\Grpc\Client\Internal;
+
+use Amp\Cancellation;
+use Amp\Http\Client\DelegateHttpClient;
+use Amp\NullCancellation;
+use Thesis\Grpc\Client;
+use Thesis\Grpc\ClientStream;
+use Thesis\Grpc\Compression;
+use Thesis\Grpc\Encoding;
+use Thesis\Grpc\Metadata;
+use Thesis\Protobuf\Decoder;
+
+/**
+ * @internal
+ */
+final readonly class AmphpHttpClient implements Client
+{
+    private Http2\InterceptorComposer $interceptor;
+
+    private Http2\StreamFactory $streams;
+
+    /**
+     * @param non-empty-string $host
+     * @param list<Client\Interceptor> $interceptors
+     */
+    public function __construct(
+        string $host,
+        DelegateHttpClient $client,
+        Encoding\Encoder $encoder,
+        Compression\Compressor $compressor,
+        Decoder $protobuf,
+        array $interceptors = [],
+    ) {
+        $this->interceptor = new Http2\InterceptorComposer([
+            ...$interceptors,
+            new Http2\AppendControlMetadataInterceptor(
+                $encoder->name(),
+                $compressor->name(),
+            ),
+        ]);
+        $this->streams = new Http2\StreamFactory(
+            http: $client,
+            uri: new Http2\UriFactory($host),
+            errors: new Http2\ErrorHandler($protobuf),
+            encoder: $encoder,
+            compressor: $compressor,
+        );
+    }
+
+    #[\Override]
+    public function invoke(
+        object $request,
+        Client\Invoke $invoke,
+        Metadata $md = new Metadata(),
+        Cancellation $cancellation = new NullCancellation(),
+    ): object {
+        $stream = $this->createStream(
+            $invoke,
+            $md,
+            $cancellation,
+        );
+
+        $stream->send($request);
+        $stream->close();
+
+        return $stream->receive();
+    }
+
+    #[\Override]
+    public function createStream(
+        Client\Invoke $invoke,
+        Metadata $md = new Metadata(),
+        Cancellation $cancellation = new NullCancellation(),
+    ): ClientStream {
+        return $this->interceptor->intercept( // @phpstan-ignore return.type
+            $invoke,
+            $md,
+            $cancellation,
+            $this->streams->create(...),
+        );
+    }
+}

--- a/src/Server.php
+++ b/src/Server.php
@@ -4,30 +4,23 @@ declare(strict_types=1);
 
 namespace Thesis\Grpc;
 
-use Amp\Http\Server\HttpServer;
-use Thesis\Grpc\Server\Internal\Http2;
+use Amp\Cancellation;
+use Amp\NullCancellation;
 
 /**
  * @api
  */
-final readonly class Server
+interface Server
 {
-    public function __construct(
-        private HttpServer $server,
-        private Http2\ServerRequestHandler $requestHandler,
-        private Http2\ServerErrorHandler $errorHandler,
-    ) {}
+    /**
+     * The server can subscribe to the {@see Cancellation} to stop automatically when it is triggered, for example on a signal.
+     * Starting the server does not block the application. If you need to wait for the server to stop, wrap the call in a {@see \Amp\async()} and await it.
+     */
+    public function start(Cancellation $cancellation = new NullCancellation()): void;
 
-    public function start(): void
-    {
-        $this->server->start(
-            $this->requestHandler,
-            $this->errorHandler,
-        );
-    }
-
-    public function stop(): void
-    {
-        $this->server->stop();
-    }
+    /**
+     * Calling this method will attempt to gracefully finish processing all ongoing requests.
+     * To prevent this from taking too long, you can provide a {@see Cancellation} that, once triggered, will cause the server to stop waiting and shutdown immediately.
+     */
+    public function stop(Cancellation $cancellation = new NullCancellation()): void;
 }

--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -373,7 +373,7 @@ final class Builder
             $server->expose($address, $bindContext);
         }
 
-        return new Server(
+        return new Internal\AmphpHttpServer(
             server: $server,
             requestHandler: new ServerRequestHandler(
                 encoderFactory: new MessageEncoderFactory(array_values($this->encoders)),

--- a/src/Server/Internal/AmphpHttpServer.php
+++ b/src/Server/Internal/AmphpHttpServer.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Thesis\Grpc\Server\Internal;
+
+use Amp\Cancellation;
+use Amp\Http\Server\HttpServer;
+use Amp\NullCancellation;
+use Thesis\Grpc\Server;
+
+/**
+ * @internal
+ */
+final readonly class AmphpHttpServer implements Server
+{
+    public function __construct(
+        private HttpServer $server,
+        private Http2\ServerRequestHandler $requestHandler,
+        private Http2\ServerErrorHandler $errorHandler,
+    ) {}
+
+    #[\Override]
+    public function start(Cancellation $cancellation = new NullCancellation()): void
+    {
+        $this->server->start(
+            $this->requestHandler,
+            $this->errorHandler,
+        );
+    }
+
+    #[\Override]
+    public function stop(Cancellation $cancellation = new NullCancellation()): void
+    {
+        $this->server->stop();
+    }
+}


### PR DESCRIPTION
To make it easier to swap the underlying implementation in the future and to evolve the client and server APIs independently, both are now defined as interfaces. The concrete implementations are encapsulated in and configured via the respective client and server builders.