### PR TITLE
Fix `ClientStream::close()` behaviour

### DIFF
--- a/src/Client/Internal/Http2/StreamFactory.php
+++ b/src/Client/Internal/Http2/StreamFactory.php
@@ -54,7 +54,7 @@ final readonly class StreamFactory
         Cancellation $cancellation = new NullCancellation(),
     ): ClientStream {
         /** @var Pipeline\Queue<In> $send */
-        $send = new Pipeline\Queue(1);
+        $send = new Pipeline\Queue();
 
         /** @var DeferredFuture<null> $deferred */
         $deferred = new DeferredFuture();
@@ -74,7 +74,7 @@ final readonly class StreamFactory
         // causing an error on the server side — after a certain timeout, the server will detect that the client unexpectedly closed the connection.
         // Therefore, after calling {@see ConcurrentClientStream::close()}, we must wait for a future that completes successfully
         // only after the entire body and trailers have been successfully transmitted to the server.
-        $request->addEventListener(new RequestEventListener()->onRequestEnd($deferred->complete(...))); // @phpstan-ignore argument.type
+        $request->addEventListener(new RequestEventListener()->onRequestBodyEnd($deferred->complete(...))); // @phpstan-ignore argument.type
 
         /** @var Future<Response> $response */
         $response = async($this->http->request(...), $request, $cancellation);


### PR DESCRIPTION
Fix premature blocking on server streaming requests on the client side.

When using server streaming, the client sends a request, calls `close()` immediately, and starts reading the response. Previously, the future was synchronized on the `onRequestEnd()` event, which caused the client to wait until the server closed the stream on its side before receiving any messages. This was incorrect.

A request should be considered successfully sent as soon as the request body has been fully transmitted. Errors caused by unexpectedly closed streams — which the previous code attempted to handle — should be handled on the server side instead.