### PR TITLE
Add Encoder generics

### DIFF
--- a/packages/grpc/src/Encoding/Encoder.php
+++ b/packages/grpc/src/Encoding/Encoder.php
@@ -6,6 +6,7 @@ namespace Thesis\Grpc\Encoding;
 
 /**
  * @api
+ * @template T of object = object
  */
 interface Encoder
 {
@@ -17,16 +18,15 @@ interface Encoder
     public function name(): string;
 
     /**
-     * @template T of object
      * @param T $request
      * @throws EncodingFailed
      */
     public function encode(object $request): string;
 
     /**
-     * @template T of object
-     * @param class-string<T> $classType
-     * @return T
+     * @template E of T
+     * @param class-string<E> $classType
+     * @return E
      * @throws DecodingFailed
      */
     public function decode(string $buffer, string $classType): object;


### PR DESCRIPTION
Generics will allow writing encoders with a more specific type than `object`. For example, this makes it possible to implement a `RawMessageEncoder` that enables using a protobuf serializer other than `thesis/protobuf` (e.g google/protobuf).

```php
/**
 * @api
 */
final readonly class RawMessage
{
    public function __construct(
        public string $payload,
    ) {}
}

/**
 * @template-implements Encoder<RawMessage>
 */
final readonly class RawMessageEncoder implements Encoder
{
	#[\Override]
    public function name(): string
	{
		return 'proto';
	}

    #[\Override]
    public function encode(object $request): string
	{
		return $request->payload;
	}

    #[\Override]
    public function decode(string $buffer, string $classType): object
	{
		return new $classType($buffer);
	}
}
```